### PR TITLE
feat(cli): holly update-check — daily version check with GitHub releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "holly-mcp",
  "serde_json",
  "tokio",
+ "ureq",
 ]
 
 [[package]]

--- a/holly-cli/Cargo.toml
+++ b/holly-cli/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1"
 anyhow = "1"
 dirs = "5"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+ureq = { version = "2", features = ["json"] }

--- a/holly-cli/src/commands/mod.rs
+++ b/holly-cli/src/commands/mod.rs
@@ -17,3 +17,4 @@ pub mod search;
 pub mod stats;
 pub mod tag;
 pub mod task;
+pub mod update_check;

--- a/holly-cli/src/commands/update_check.rs
+++ b/holly-cli/src/commands/update_check.rs
@@ -1,0 +1,124 @@
+use anyhow::Result;
+use serde_json::Value;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const REPO: &str = "plaxdan/holly-db";
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const CACHE_TTL_SECS: u64 = 86_400; // 24 hours
+
+pub fn run(verbose: bool) -> Result<()> {
+    let cache_path = cache_file();
+
+    let cached = read_cache(&cache_path);
+    let now = unix_now();
+
+    // Use cache if it's still fresh
+    let latest = if let Some((checked_at, version)) = cached {
+        if now.saturating_sub(checked_at) < CACHE_TTL_SECS {
+            version
+        } else {
+            fetch_latest().unwrap_or(version)
+        }
+    } else {
+        match fetch_latest() {
+            Ok(v) => v,
+            Err(_) => {
+                // Network unavailable — stay silent
+                if verbose {
+                    eprintln!("holly update-check: could not reach GitHub (offline?)");
+                }
+                return Ok(());
+            }
+        }
+    };
+
+    write_cache(&cache_path, now, &latest);
+
+    if is_newer(&latest, CURRENT_VERSION) {
+        println!(
+            "holly update available: {} → {}  (https://github.com/{}/releases/latest)",
+            CURRENT_VERSION, latest, REPO
+        );
+    } else if verbose {
+        println!("holly is up to date ({})", CURRENT_VERSION);
+    }
+
+    Ok(())
+}
+
+fn fetch_latest() -> Result<String> {
+    let url = format!("https://api.github.com/repos/{}/releases/latest", REPO);
+    let response = ureq::get(&url)
+        .set("User-Agent", &format!("holly-db/{}", CURRENT_VERSION))
+        .set("Accept", "application/vnd.github+json")
+        .call();
+
+    let body: Value = match response {
+        Ok(r) => r.into_json()?,
+        Err(ureq::Error::Status(404, _)) => {
+            // No releases published yet — treat as up to date
+            return Ok(CURRENT_VERSION.to_string());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let tag = body["tag_name"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("no tag_name in response"))?
+        .trim_start_matches('v')
+        .to_string();
+
+    Ok(tag)
+}
+
+/// Parse "M.m.p" into (major, minor, patch) for comparison.
+fn parse_version(v: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = v.trim_start_matches('v').splitn(3, '.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+    Some((major, minor, patch))
+}
+
+fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_version(latest), parse_version(current)) {
+        (Some(l), Some(c)) => l > c,
+        _ => false,
+    }
+}
+
+fn cache_file() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("holly")
+        .join("update-check.json")
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn read_cache(path: &PathBuf) -> Option<(u64, String)> {
+    let content = fs::read_to_string(path).ok()?;
+    let v: Value = serde_json::from_str(&content).ok()?;
+    let checked_at = v["checked_at"].as_u64()?;
+    let version = v["latest_version"].as_str()?.to_string();
+    Some((checked_at, version))
+}
+
+fn write_cache(path: &PathBuf, now: u64, latest: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let content = serde_json::json!({
+        "checked_at": now,
+        "latest_version": latest,
+        "current_version": CURRENT_VERSION,
+    });
+    let _ = fs::write(path, content.to_string());
+}

--- a/holly-cli/src/main.rs
+++ b/holly-cli/src/main.rs
@@ -219,6 +219,14 @@ enum Commands {
         remove: bool,
     },
 
+    /// Check for a newer version of holly
+    #[command(name = "update-check")]
+    UpdateCheck {
+        /// Print current version even if up to date
+        #[arg(long)]
+        verbose: bool,
+    },
+
     /// Import from a legacy Holly database
     Import {
         /// Path to legacy holly.db
@@ -355,6 +363,11 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             return commands::init::download_model();
         }
         return commands::init::run(*global, cli.db.as_deref());
+    }
+
+    // `update-check` — no DB needed
+    if let Commands::UpdateCheck { verbose } = &cli.command {
+        return commands::update_check::run(*verbose);
     }
 
     // `mcp-server` opens its own DB inside the async runtime
@@ -579,6 +592,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             commands::reindex::run(&db, json)?;
         }
 
+        Commands::UpdateCheck { .. } => unreachable!("handled above"),
         Commands::McpServer => unreachable!("handled above"),
         Commands::Mcp { .. } => unreachable!("handled above"),
     }


### PR DESCRIPTION
## Summary

- Adds `holly update-check` subcommand to check for newer releases
- Queries GitHub releases API, caches result 24h in XDG cache dir
- Exits silently when up to date; one-line notice when update available
- Handles no-releases-yet (404) and network failures gracefully
- `--verbose` flag shows current version even when up to date

## Test plan

- [x] `holly update-check` — silent when up to date (no output, exit 0)
- [x] `holly update-check --verbose` — prints current version
- [x] 404 from API (no releases yet) handled as up to date
- [x] 58/58 tests passing

closes #1