### PR TITLE
ci: use macos-14 runner for x86_64-apple-darwin release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-14
           - target: aarch64-apple-darwin
             os: macos-latest
 


### PR DESCRIPTION
macos-13 runners have regional availability issues causing the release build to fail. macos-14 (arm64) can cross-compile x86_64-apple-darwin correctly via the Rust toolchain.