### PR TITLE
feat(cli): add holly artifact link subcommand

### DIFF
--- a/holly-cli/src/commands/artifact.rs
+++ b/holly-cli/src/commands/artifact.rs
@@ -1,0 +1,76 @@
+use holly_core::{CreateNodeInput, HollyDb};
+use std::path::Path;
+
+#[allow(clippy::too_many_arguments)]
+pub fn link(
+    db: &HollyDb,
+    task_id: &str,
+    path: &str,
+    title: Option<&str>,
+    run_id: Option<&str>,
+    notes: Option<&str>,
+    artifact_type: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    // Verify task exists (also resolves 8-char prefix to full UUID)
+    let task = db.get_node(task_id)?;
+
+    // Default title to the filename component of path
+    let default_title;
+    let resolved_title = match title {
+        Some(t) => t,
+        None => {
+            default_title = Path::new(path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(path)
+                .to_string();
+            &default_title
+        }
+    };
+
+    let mut content = serde_json::json!({
+        "status": "recorded",
+        "artifact_type": artifact_type,
+        "path": path,
+        "task_id": task.id,
+        "run_id": run_id.unwrap_or(""),
+    });
+
+    if let Some(n) = notes {
+        content["notes"] = serde_json::Value::String(n.to_string());
+    }
+
+    let artifact = db.create_node(CreateNodeInput {
+        node_type: "artifact".to_string(),
+        title: resolved_title.to_string(),
+        content: Some(content),
+        status: Some("recorded".to_string()),
+        ..Default::default()
+    })?;
+
+    // Link artifact → task
+    let _ = db.create_edge(&artifact.id, &task.id, "relates_to", None);
+
+    // Link artifact → run if provided
+    if let Some(rid) = run_id {
+        if !rid.is_empty() {
+            // Verify run exists before linking (best-effort; ignore lookup errors)
+            if let Ok(run) = db.get_node(rid) {
+                let _ = db.create_edge(&artifact.id, &run.id, "relates_to", None);
+            }
+        }
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&artifact)?);
+    } else {
+        println!(
+            "Artifact linked [{}]: {} → task [{}]",
+            &artifact.id[..8],
+            artifact.title,
+            &task.id[..8],
+        );
+    }
+    Ok(())
+}

--- a/holly-cli/src/commands/mod.rs
+++ b/holly-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod artifact;
 pub mod audit;
 pub mod connect;
 pub mod context;

--- a/holly-cli/src/main.rs
+++ b/holly-cli/src/main.rs
@@ -207,6 +207,12 @@ enum Commands {
         action: RunAction,
     },
 
+    /// Artifact operations
+    Artifact {
+        #[command(subcommand)]
+        action: ArtifactAction,
+    },
+
     /// Add or remove tags on a node
     Tag {
         id: String,
@@ -338,6 +344,36 @@ enum RunAction {
 
         #[arg(long)]
         summary: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ArtifactAction {
+    /// Link an artifact to a task (and optionally a run)
+    Link {
+        /// Task node ID (full UUID or 8-char prefix)
+        #[arg(long)]
+        task: String,
+
+        /// Artifact path or locator
+        #[arg(long)]
+        path: String,
+
+        /// Artifact title (defaults to filename component of path)
+        #[arg(long)]
+        title: Option<String>,
+
+        /// Optional run node ID to link as well
+        #[arg(long)]
+        run: Option<String>,
+
+        /// Optional notes
+        #[arg(long)]
+        notes: Option<String>,
+
+        /// Artifact type (default: evidence)
+        #[arg(long, default_value = "evidence")]
+        r#type: String,
     },
 }
 
@@ -577,6 +613,28 @@ fn run(cli: Cli) -> anyhow::Result<()> {
                 summary,
             } => {
                 commands::run::complete(&db, &id, status.as_deref(), summary.as_deref(), json)?;
+            }
+        },
+
+        Commands::Artifact { action } => match action {
+            ArtifactAction::Link {
+                task,
+                path,
+                title,
+                run,
+                notes,
+                r#type,
+            } => {
+                commands::artifact::link(
+                    &db,
+                    &task,
+                    &path,
+                    title.as_deref(),
+                    run.as_deref(),
+                    notes.as_deref(),
+                    &r#type,
+                    json,
+                )?;
             }
         },
 


### PR DESCRIPTION
## Summary

Adds `holly artifact link` CLI subcommand, closing the gap where `holly_task_link_artifact` was only accessible via the MCP server.

```
holly artifact link --task <id> --path <path> [--title <title>] [--run <id>] [--notes <notes>] [--type <type>]
```

- `--task` — task node ID (8-char prefix supported)
- `--path` — artifact path or locator
- `--title` — defaults to filename component of path
- `--run` — optional run node to link
- `--notes` — optional notes
- `--type` — artifact type (default: `evidence`)
- `--json` — JSON output consistent with all other commands

## Motivation

`vsd-lifecycle-record.mjs` in antifactory was forced to depend on `@modelcontextprotocol/sdk` solely because artifact linking had no CLI equivalent. With this command, VSD scripts can use the `holly` binary directly with no MCP client dependency.

## Test plan

- [ ] 58/58 tests pass (`cargo test --locked`)
- [ ] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [ ] `holly artifact link --task <id> --path ./foo.json` creates artifact node and edge
- [ ] `--json` flag produces parseable JSON output